### PR TITLE
Add "multipod_team" tag to bite DAG

### DIFF
--- a/dags/imagegen_devx/project_bite.py
+++ b/dags/imagegen_devx/project_bite.py
@@ -28,7 +28,7 @@ SCHEDULED_TIME = "0 18 * * *" if composer_env.is_prod_env() else None
 with models.DAG(
     dag_id="project_bite",
     schedule=SCHEDULED_TIME,
-    tags=["imagegen_devx", "jax", "nightly", "bite"],
+    tags=["imagegen_devx", "jax", "nightly", "bite", "multipod_team"],
     start_date=datetime.datetime(2024, 4, 4),
     catchup=False,
 ) as dag:


### PR DESCRIPTION
# Description

Our airflow UI filters in the "multipod_team" tag by default, and we want to track the bite DAG. 